### PR TITLE
Prevent filter values from becoming undefined

### DIFF
--- a/components/Filters.jsx
+++ b/components/Filters.jsx
@@ -60,7 +60,10 @@ function handleInputChange(handleChange, query) {
     // so we're using a period delimiter to denote depth
     const [topKey, subKey] = keys.split(".");
     const currentValue = query[topKey];
-    handleChange({ key: topKey, value: { ...currentValue, [subKey]: value } });
+    handleChange({
+      key: topKey,
+      value: { ...currentValue, [subKey]: value ?? 0 }
+    });
   };
 }
 

--- a/components/Results.jsx
+++ b/components/Results.jsx
@@ -23,8 +23,17 @@ const PagerContainer = styled.div`
  * @property {ReturnType<typeof import('hooks/usePokemonDataFilters')['default']>['results']} ResultsProps.results
  * @param {ResultsProps} { results }
  */
-export default function Results({ results = [], pagination, total }) {
+export default function Results({ results, pagination, total }) {
   const { active, setPage } = pagination;
+  const hasNoResults = results.length === 0;
+
+  if (hasNoResults) {
+    return (
+      <div>
+        <PaddedTitle>No Results</PaddedTitle>
+      </div>
+    );
+  }
 
   return (
     <div>


### PR DESCRIPTION
It was possible for the results panel to become empty whenever numeric filters were completely cleared (ie. the user completely backspaces the value).

This can no longer happen as numeric inputs fields will always have their handlers submit a zero value in place of any null/undefined value. 