### PR TITLE
add tier rankings next to base stat values

### DIFF
--- a/components/Results.jsx
+++ b/components/Results.jsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { Table, List, Container, Pagination } from "@mantine/core";
 import PaddedTitle from "components/PaddedTitle";
+import getTier from "utils/getTier";
 
 const FlexList = styled(List)`
   display: flex;
@@ -64,26 +65,15 @@ export default function Results({ results, pagination, total }) {
               <tbody>
                 <tr>
                   {Object.entries(data.baseStats).map(([label, value]) => (
-                    <td key={label}>{value}</td>
-                  ))}
-                </tr>
-              </tbody>
-            </Table>
-            <Table>
-              <thead>
-                <tr>
-                  <th>HP Quantile</th>
-                  <th>ATK Quantile</th>
-                  <th>DEF Quantile</th>
-                  <th>SPA Quantile</th>
-                  <th>SPD Quantile</th>
-                  <th>Speed Quantile</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  {Object.entries(data.quantiles).map(([label, value]) => (
-                    <td key={label}>{value.toFixed(2)}</td>
+                    <td key={label}>
+                      {value}
+                      <sup>
+                        {" "}
+                        <strong>
+                          {getTier(data.quantiles[label] * 100)}-Tier
+                        </strong>
+                      </sup>
+                    </td>
                   ))}
                 </tr>
               </tbody>

--- a/data/pokemon-results-list.js
+++ b/data/pokemon-results-list.js
@@ -111,12 +111,12 @@ const pokemonResultList = pokemonList
     // apply quantile ranks
     ...data,
     quantiles: {
-      hp: getQuantileRk(data, 0),
-      atk: getQuantileRk(data, 1),
-      def: getQuantileRk(data, 2),
-      spa: getQuantileRk(data, 3),
-      spd: getQuantileRk(data, 4),
-      speed: getQuantileRk(data, 5)
+      baseHP: getQuantileRk(data, 0),
+      baseAtk: getQuantileRk(data, 1),
+      baseDef: getQuantileRk(data, 2),
+      baseSpa: getQuantileRk(data, 3),
+      baseSpd: getQuantileRk(data, 4),
+      baseSpeed: getQuantileRk(data, 5)
     }
   }))
   .map((data) => ({

--- a/utils/getTier.js
+++ b/utils/getTier.js
@@ -1,0 +1,25 @@
+const getLabel = (label, upper, lower) => (query) => {
+  return query >= lower && query <= upper ? label : false;
+};
+
+const byTruthyValue = (value) => (testFn) => testFn(value);
+
+/**
+ * @description provides tier-list ranking on a 0 - 100 scale,
+ * based on the numeric input provided (ie. 85 is "B")
+ * @param {number} query numeric query
+ * @returns {"S"|"A"|"B"|"C"|"D"} tier ranking
+ */
+export default function getTier(query) {
+  const S = getLabel("S", Infinity, 99);
+  const A = getLabel("A", 98, 90);
+  const B = getLabel("B", 89, 80);
+  const C = getLabel("C", 79, 70);
+  const D = getLabel("D", 69, -Infinity);
+
+  const roundedQuery = Math.round(query);
+
+  const applyTier = [S, A, B, C, D].find(byTruthyValue(roundedQuery));
+
+  return applyTier(roundedQuery);
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29016813/205513468-018d3d3a-bb3a-4c07-9ed6-e3ea774b977b.png)

This PR removes the quantile rank table and moves its data into the base stats table as tier list rankings, ranging from S-Tier to D-Tier.

I believe the information is easier to digest when formatted this way.