### PR TITLE
Add matchup finder

### DIFF
--- a/components/MatchupFinderInputs.jsx
+++ b/components/MatchupFinderInputs.jsx
@@ -1,0 +1,53 @@
+import { Container, Select } from "@mantine/core";
+import { asTable as pokemonTable } from "data/pokemon-results-list";
+import { asList as typeList } from "data/type-table";
+import {
+  EVENT_SEND_RAID_BOSS,
+  EVENT_SEND_TERA_TYPE
+} from "hooks/useRaidBossMatchupFinder";
+
+const raidBossSelectOptions = Object.keys(pokemonTable)
+  .sort()
+  .map((name) => ({ label: name, value: name }));
+
+const typeSelectOptions = typeList.map((value) => ({
+  label: value,
+  value: value
+}));
+
+function onSelectChange(send) {
+  return (type) => (value) => {
+    if (typeof send === "function") {
+      send({ type, data: { value } });
+    }
+  };
+}
+
+/**
+ * @typedef {Object} MatchupFinderInputsProps
+ * @property {(event: { type: string; data: any }) => void} props.send possible event handler
+ * @param {MatchupFinderInputsProps} props
+ */
+export default function MatchupFinderInputs(props) {
+  const { send } = props;
+  const handleSelectChange = onSelectChange(send);
+
+  return (
+    <Container>
+      <Select
+        data={raidBossSelectOptions}
+        label="Raid Boss"
+        onChange={handleSelectChange(EVENT_SEND_RAID_BOSS)}
+        placeholder="Select Raid Boss"
+        searchable
+      />
+      <Select
+        data={typeSelectOptions}
+        label="Raid Boss Tera Type"
+        onChange={handleSelectChange(EVENT_SEND_TERA_TYPE)}
+        placeholder="Select Tera Type"
+        searchable
+      />
+    </Container>
+  );
+}

--- a/data/pokemon-results-list.js
+++ b/data/pokemon-results-list.js
@@ -168,5 +168,7 @@ const pokemonResultList = pokemonList
       typeCoverage
     };
   });
-
+export const asTable = Object.fromEntries(
+  pokemonResultList.map((p) => [p.name, p])
+);
 export default pokemonResultList;

--- a/data/type-table.js
+++ b/data/type-table.js
@@ -1,3 +1,5 @@
+import capitalizeFirstChar from "utils/capitalizeFirstChar";
+
 const typeTable = {
   // which move types are super effective against other types?
   // ie. bug type moves are "super effective" against grass-type pokemon
@@ -56,5 +58,9 @@ const typeTable = {
     water: ["Water", "Steel"]
   }
 };
+
+export const asList = Object.keys(typeTable.attacking)
+  .sort()
+  .map((type) => capitalizeFirstChar(type));
 
 export default typeTable;

--- a/hooks/usePokemonDataFilters.js
+++ b/hooks/usePokemonDataFilters.js
@@ -18,6 +18,7 @@ export const initialQuery = {
   baseAtk: { op: "gte", value: 0 },
   baseDef: { op: "gte", value: 0 },
   baseSpa: { op: "gte", value: 0 },
+  baseSpd: { op: "gte", value: 0 },
   baseSpeed: { op: "gte", value: 0 }
 };
 
@@ -70,6 +71,7 @@ export default function usePokemonDataFilters() {
     baseAtk,
     baseDef,
     baseSpa,
+    baseSpd,
     baseSpeed
   } = query;
 
@@ -84,6 +86,7 @@ export default function usePokemonDataFilters() {
         "baseStats.baseAtk": { [`$${baseAtk.op}`]: baseAtk.value },
         "baseStats.baseDef": { [`$${baseDef.op}`]: baseDef.value },
         "baseStats.baseSpa": { [`$${baseSpa.op}`]: baseSpa.value },
+        "baseStats.baseSpd": { [`$${baseSpd.op}`]: baseSpd.value },
         "baseStats.baseSpeed": { [`$${baseSpeed.op}`]: baseSpeed.value }
       })
     )

--- a/hooks/useRaidBossMatchupFinder.js
+++ b/hooks/useRaidBossMatchupFinder.js
@@ -1,0 +1,109 @@
+import { useMemo } from "react";
+import { createMachine, assign } from "xstate";
+import { useMachine } from "@xstate/react";
+import { asTable as pokemonTable } from "data/pokemon-results-list";
+import usePokemonDataFilters from "hooks/usePokemonDataFilters";
+
+// Event Types
+export const EVENT_SEND_RAID_BOSS = "SEND_RAID_BOSS";
+export const EVENT_SEND_TERA_TYPE = "SEND_TERA_TYPE";
+
+// States
+const STATE_IDLE = "IDLE";
+const STATE_FILTERING = "FILTERING";
+// should the machine transition to idle or filtering state
+const STATE_THINKING = "THINKING";
+
+// Guards
+const canFilter = ({ raidBossName, teraType }) => {
+  // ensure each value is not falsy
+  const hasValues = [raidBossName, teraType].every(Boolean);
+
+  return hasValues;
+};
+
+// Actions
+const setRaidBossName = assign({
+  raidBossName: (context, event) => (context.raidBossName = event.data.value)
+});
+
+const setTeraType = assign({
+  teraType: (context, event) => (context.teraType = event.data.value)
+});
+
+const sendFilters =
+  (handleChange) =>
+  ({ raidBossName, teraType }) => {
+    const raidBoss = pokemonTable[raidBossName];
+
+    const raidBossTypes = raidBoss.types;
+
+    // must be able to resist these types
+    handleChange({ key: "resistances", value: raidBossTypes });
+    // should be effective against the tera type
+    handleChange({ key: "typeCoverage", value: [teraType] });
+  };
+
+const raidBossMatchupMachine = (handleChange) =>
+  createMachine(
+    {
+      id: "raid-boss-matchups",
+      initial: STATE_IDLE,
+      predictableActionArguments: true,
+      context: {
+        raidBossName: "",
+        teraType: ""
+      },
+      states: {
+        [STATE_IDLE]: {
+          on: {
+            [EVENT_SEND_RAID_BOSS]: {
+              target: STATE_THINKING,
+              actions: ["setRaidBossName"]
+            },
+            [EVENT_SEND_TERA_TYPE]: {
+              target: STATE_THINKING,
+              actions: ["setTeraType"]
+            }
+          }
+        },
+        [STATE_THINKING]: {
+          always: [
+            { target: STATE_FILTERING, cond: canFilter },
+            { target: STATE_IDLE }
+          ]
+        },
+        [STATE_FILTERING]: {
+          always: [{ target: STATE_IDLE, actions: ["sendFilters"] }]
+        }
+      }
+    },
+    {
+      actions: {
+        setRaidBossName,
+        setTeraType,
+        sendFilters: sendFilters(handleChange)
+      }
+    }
+  );
+
+export default function useRaidBossMatchupFinder() {
+  const { handleChange, results } = usePokemonDataFilters();
+  const machine = useMemo(
+    () => raidBossMatchupMachine(handleChange),
+    [handleChange]
+  );
+  /**
+   * A new machine is created on render, xstate doesn't like this,
+   * but it appears to work just fine here.
+   * See this github issue for more information:
+   * https://github.com/statelyai/xstate/issues/995
+   */
+  const [_state, send] = useMachine(machine);
+
+  return { send, results };
+}
+
+/**
+ * Why does this exist?
+ */

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.10.5",
         "@mantine/core": "^5.9.0",
         "@mantine/hooks": "^5.9.0",
+        "@xstate/react": "^3.0.1",
         "eslint": "8.28.0",
         "eslint-config-next": "13.0.5",
         "next": "13.0.5",
@@ -18,7 +19,8 @@
         "react-dom": "18.2.0",
         "sift": "^16.0.1",
         "simple-statistics": "^7.8.0",
-        "styled-components": "^5.3.6"
+        "styled-components": "^5.3.6",
+        "xstate": "^4.34.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1295,6 +1297,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@xstate/react": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.0.1.tgz",
+      "integrity": "sha512-/tq/gg92P9ke8J+yDNDBv5/PAxBvXJf2cYyGDByzgtl5wKaxKxzDT82Gj3eWlCJXkrBg4J5/V47//gRJuVH2fA==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@xstate/fsm": "^2.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "xstate": "^4.33.0"
+      },
+      "peerDependenciesMeta": {
+        "@xstate/fsm": {
+          "optional": true
+        },
+        "xstate": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {
@@ -4190,6 +4214,14 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4231,6 +4263,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xstate": {
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.34.0.tgz",
+      "integrity": "sha512-MFnYz7cJrWuXSZ8IPkcCyLB1a2T3C71kzMeShXKmNaEjBR/JQebKZPHTtxHKZpymESaWO31rA3IQ30TC6LW+sw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -5143,6 +5184,15 @@
       "requires": {
         "@typescript-eslint/types": "5.45.0",
         "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@xstate/react": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.0.1.tgz",
+      "integrity": "sha512-/tq/gg92P9ke8J+yDNDBv5/PAxBvXJf2cYyGDByzgtl5wKaxKxzDT82Gj3eWlCJXkrBg4J5/V47//gRJuVH2fA==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.0.0",
+        "use-sync-external-store": "^1.0.0"
       }
     },
     "acorn": {
@@ -7151,6 +7201,12 @@
         "use-isomorphic-layout-effect": "^1.1.1"
       }
     },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7180,6 +7236,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "xstate": {
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.34.0.tgz",
+      "integrity": "sha512-MFnYz7cJrWuXSZ8IPkcCyLB1a2T3C71kzMeShXKmNaEjBR/JQebKZPHTtxHKZpymESaWO31rA3IQ30TC6LW+sw=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.9.0",
     "@mantine/hooks": "^5.9.0",
+    "@xstate/react": "^3.0.1",
     "eslint": "8.28.0",
     "eslint-config-next": "13.0.5",
     "next": "13.0.5",
@@ -19,6 +20,7 @@
     "react-dom": "18.2.0",
     "sift": "^16.0.1",
     "simple-statistics": "^7.8.0",
-    "styled-components": "^5.3.6"
+    "styled-components": "^5.3.6",
+    "xstate": "^4.34.0"
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import FilterWithResults from "views/FilterWithResults";
+import Landing from "views/Landing";
 
 export default function Home() {
   return (
@@ -13,7 +13,7 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main>
-        <FilterWithResults />
+        <Landing />
       </main>
     </div>
   );

--- a/utils/chunkArr.js
+++ b/utils/chunkArr.js
@@ -6,7 +6,7 @@ export default function chunkArr(arr = [], size = 10) {
 
   // arr len of 5
   // 5 / 10 = 0.5 (1 chunk)
-  const totalChunks = range(Math.round(arr.length / size));
+  const totalChunks = range(Math.ceil(arr.length / size));
 
   // I didn't want to use any control flow statements
   // so elected to use a array mutating method (splice)

--- a/views/Landing.jsx
+++ b/views/Landing.jsx
@@ -1,0 +1,21 @@
+import { Tabs, Container } from "@mantine/core";
+import FilterWithResults from "views/FilterWithResults";
+import MatchupFinder from "views/MatchupFinder";
+export default function Landing() {
+  return (
+    <Container>
+      <Tabs defaultValue="matchups">
+        <Tabs.List>
+          <Tabs.Tab value="matchups">Matchups</Tabs.Tab>
+          <Tabs.Tab value="explorer">Explorer</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel value="matchups">
+          <MatchupFinder />
+        </Tabs.Panel>
+        <Tabs.Panel value="explorer">
+          <FilterWithResults />
+        </Tabs.Panel>
+      </Tabs>
+    </Container>
+  );
+}

--- a/views/MatchupFinder.jsx
+++ b/views/MatchupFinder.jsx
@@ -1,0 +1,17 @@
+import { Container } from "@mantine/core";
+import usePager from "hooks/usePager";
+import MatchupFinderInputs from "components/MatchupFinderInputs";
+import Results from "components/Results";
+import useRaidBossMatchupFinder from "hooks/useRaidBossMatchupFinder";
+
+export default function MatchupFinder() {
+  const { send, results } = useRaidBossMatchupFinder();
+  const { pagination, total, currentResults } = usePager(results);
+  console.log({ total, currentResults, results });
+  return (
+    <Container>
+      <MatchupFinderInputs send={send} />
+      <Results results={currentResults} pagination={pagination} total={total} />
+    </Container>
+  );
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29016813/205744341-8c50e79d-2ee3-4ced-8d32-7b0264ed4ec1.png)

### Matchup Finder

#### The current application works well for what I initially wanted, but it's a bit tedious
- I need to enter the types of pokemon I want to attack against, but what if that pokemon is highly offensive/defensive?
	- For instance, I select the types of ground and dragon to defend against, and a tera type of ice
		- This sounds like a Garchomp, but is it?
		- What pokemon can reasonably defend against ground and dragon, and be effective against ice?
		