### PR TITLE
Filter out neutral types

### DIFF
--- a/data/pokemon-results-list.js
+++ b/data/pokemon-results-list.js
@@ -1,3 +1,4 @@
+import { intersection } from "lodash";
 import { quantileRank } from "simple-statistics";
 import pokemonTable from "data/pokemon-table";
 import typeTable from "data/type-table";
@@ -167,6 +168,22 @@ const pokemonResultList = pokemonList
       ...data,
       typeCoverage
     };
+  })
+  .map((data) => {
+    // pokemon with dual types may have weaknesses and resistances
+    // which cancel each other out, remove any intersecting resistances/weaknesses
+    // as they shall be seen as neutral coverage
+    const intersectingDefenses = intersection(
+      data.resistances,
+      data.weaknesses
+    );
+    const resistances = data.resistances.filter(
+      (r) => !intersectingDefenses.includes(r)
+    );
+    const weaknesses = data.weaknesses.filter(
+      (w) => !intersectingDefenses.includes(w)
+    );
+    return { ...data, resistances, weaknesses };
   });
 export const asTable = Object.fromEntries(
   pokemonResultList.map((p) => [p.name, p])

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@xstate/react": "^3.0.1",
         "eslint": "8.28.0",
         "eslint-config-next": "13.0.5",
+        "lodash": "^4.17.21",
         "next": "13.0.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@xstate/react": "^3.0.1",
     "eslint": "8.28.0",
     "eslint-config-next": "13.0.5",
+    "lodash": "^4.17.21",
     "next": "13.0.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
This change removes any intersecting defensive coverages between a pokemon's weaknesses and resistances.

ie, Charizard is both a flying type and fire type pokemon. Both the flying and fire types have a conflict of defensive weaknesses and resistance in the ground type. Flying is immune to ground, and fire is not. Charizard actually has immunity to this type, but for now, we'll ignore it and revisit it later. 