### PR TITLE
Add type immunities

### DIFF
--- a/data/pokemon-results-list.js
+++ b/data/pokemon-results-list.js
@@ -171,6 +171,10 @@ const pokemonResultList = pokemonList
     };
   })
   .map((data) => {
+    const types = data.types;
+    const immunities = Array.from(
+      new Set(types.flatMap((type) => typeTable.immunity[type.toLowerCase()]))
+    );
     // pokemon with dual types may have weaknesses and resistances
     // which cancel each other out, remove any intersecting resistances/weaknesses
     // as they shall be seen as neutral coverage
@@ -178,9 +182,9 @@ const pokemonResultList = pokemonList
       data.resistances,
       data.weaknesses
     );
-    const resistances = data.resistances.filter(
-      (r) => !intersectingDefenses.includes(r)
-    );
+    const resistances = data.resistances
+      .filter((r) => !intersectingDefenses.includes(r))
+      .concat(immunities);
     const weaknesses = data.weaknesses.filter(
       (w) => !intersectingDefenses.includes(w)
     );

--- a/data/type-table.js
+++ b/data/type-table.js
@@ -56,6 +56,26 @@ const typeTable = {
       "Fairy"
     ],
     water: ["Water", "Steel"]
+  },
+  immunity: {
+    bug: [],
+    dark: ["Psychic"],
+    dragon: [],
+    electric: [],
+    fairy: ["Dragon"],
+    fighting: [],
+    fire: [],
+    flying: ["Ground"],
+    ghost: ["Normal", "Fighting"],
+    grass: [],
+    ground: ["Electric"],
+    ice: [],
+    normal: ["Ghost"],
+    poison: [],
+    psychic: [],
+    rock: [],
+    steel: ["Poison"],
+    water: []
   }
 };
 


### PR DESCRIPTION
To make finding viable raid matchups less tedious, I want the results sorted by special attack or attack stats, based on the raid boss' defense.